### PR TITLE
Allow py>=3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "click>=8.1.3",
     "sympy>=1.11",
 ]
-requires-python = ">=3.10,<3.11"
+requires-python = ">=3.7,<3.11"
 
 [project.scripts]
 gear = "gear.cli:main"


### PR DESCRIPTION
Updating `pyproject.toml` to allow python versions >= 3.7