### PR TITLE
65 installation not working with pdm (#67)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "pdm.pep517.api"
 name = "gear"
 description = "gear-description"
 authors = [{name = "gear-authors-name", email = "gear-authors-email"}]
-license-expression = "MIT"
+license = "BSD-2-Clause"
 readme = "README.md"
 keywords = []
 dynamic = ["version"]
@@ -14,7 +14,7 @@ dependencies = [
     "click>=8.1.3",
     "sympy>=1.11",
 ]
-requires-python = ">=3.7,<3.11"
+requires-python = ">=3.8,<3.11"
 
 [project.scripts]
 gear = "gear.cli:main"


### PR DESCRIPTION
* remove license-expression field from pyproject.toml
* change license exression to license
* change python to version >=3.8