### PR TITLE
Using infromation before it is altered

### DIFF
--- a/src/gear/iocontract/iocontract.py
+++ b/src/gear/iocontract/iocontract.py
@@ -411,10 +411,10 @@ class IoContract:
         assumptions.simplify()
 
         # process guarantees
-        g1 = self.g.copy()
-        g2 = other.g.copy()
-        g1 = g1.deduce_with_context(g2, intvars)
-        g2 = g2.deduce_with_context(g1, intvars)
+        g1_t = self.g.copy()
+        g2_t = other.g.copy()
+        g1 = g1_t.deduce_with_context(g2_t, intvars)
+        g2 = g2_t.deduce_with_context(g1_t, intvars)
         allguarantees = g1 | g2
         allguarantees = allguarantees.deduce_with_context(assumptions, intvars)
 

--- a/src/gear/terms/polyhedra/polyhedra.py
+++ b/src/gear/terms/polyhedra/polyhedra.py
@@ -570,7 +570,8 @@ class PolyhedralTermList(TermList):
             contained in the calling termlist.
         """
         termlist = self.copy()
-        logging.debug("Deducing from term %s", self)
+        logging.debug("Deduce with context")
+        logging.debug("Deducing from terms %s", self)
         logging.debug("Context: %s", context)
         logging.debug("Vars to elim: %s", vars_to_elim)
         try:


### PR DESCRIPTION
Contract composition was using relaxed guarantees as context to simplify composed guarantees.

@YuTaiwan, please verify whether this takes care of the issue.