### PR TITLE
Badges in README

### DIFF
--- a/.github/workflows/pacti_development.yml
+++ b/.github/workflows/pacti_development.yml
@@ -25,3 +25,5 @@ jobs:
         run: pdm install
       - name: Test code
         run: make test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ pip-delete-this-directory.txt
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 .hypothesis/
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Pacti 
+[![Build Status](https://github.com/pacti-org/pacti/actions/workflows/pacti_development.yml/badge.svg)](https://github.com/pacti-org/pacti/actions/workflows/pacti_development.yml)
+[![PyPI version](https://badge.fury.io/py/pacti.svg)](https://badge.fury.io/py/pacti)
+[![codecov](https://codecov.io/gh/pacti-org/pacti/branch/main/graph/badge.svg)](https://codecov.io/gh/pacti-org/pacti)
+[![Getting Started With Pacti Example](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1muppEkj1K4vowBuS1C8plCouCdK50iio?usp=sharing)
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pacti-org/media/main/docs/logos/pacti_white.png" width="250">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/pacti-org/media/main/docs/logos/pacti_colorful.png" width="250">
@@ -10,6 +15,3 @@ system using assume-guarantee specifications, or contracts. Pacti's capabilities
 - Obtaining sensible system specifications from the specifications of the constituent subsystems.
 - Computing specifications of subsystems that need to be added to a design in order to meet an objective.
 - Diagnosing incompatibilities when interconnecting components.
-
-
-


### PR DESCRIPTION
The `pacti_development` action is failing so the badge displays that it is failing but that should not stop us from merging the PR.

The code coverage badge will work when we integrate Pacti with Codecov. As far as I know, Codecov works for free for open-source repos. Same for Google Colab badge, we can create a Google Colab launch link which will let users quickly run the code with one-click. So, if we want, we can wait and merge this PR once the repo is public. What do you think @iincer?