### PR TITLE
Versioning in Pacti

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,4 @@ examples/.ipynb_checkpoints/*
 
 # Draw.io
 *.bkp
+.pdm-python

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ pip-wheel-metadata/
 site/
 pdm.lock
 .pdm.toml
+.pdm-python
 __pypackages__/
 .venv/
 .vscode/
@@ -277,4 +278,3 @@ examples/.ipynb_checkpoints/*
 
 # Draw.io
 *.bkp
-.pdm-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 keywords = ["system design", "contracts", "compositional"]
-#dynamic = ["version"]
-version = "1.0.0-alpha"
+dynamic = ["version"]
+# version = "1.0.0-alpha"
 dependencies = [
     "scipy>=1.10.0",
     "sympy>=1.11.1",
@@ -34,10 +34,10 @@ documentation = "https://www.pacti.org"
 #pacti = "pacti.cli:main"
 
 [project.optional-dependencies]
-[tool.pdm]
-version = {source = "scm"}
-package-dir = "src"
 
+[tool.pdm]
+package-dir = "src"
+version = { source = "src", path = "pacti/__version__.py" }
 
 [tool.pdm.build]
 package-dir = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ documentation = "https://www.pacti.org"
 
 [tool.pdm]
 package-dir = "src"
-version = { source = "src", path = "pacti/__version__.py" }
+version = { source = "file", path = "src/pacti/__version__.py" }
 
 [tool.pdm.build]
 package-dir = "src"

--- a/src/pacti/__init__.py
+++ b/src/pacti/__init__.py
@@ -1,1 +1,2 @@
 from .utils import read_contracts_from_file, write_contracts_to_file
+from .__version__ import __version__

--- a/src/pacti/__version__.py
+++ b/src/pacti/__version__.py
@@ -2,4 +2,4 @@
 Set the Pacti package version in this file
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.0.alpha'

--- a/src/pacti/__version__.py
+++ b/src/pacti/__version__.py
@@ -1,0 +1,6 @@
+MAJOR=1
+MINOR=0
+MICRO=0
+PATCH="alpha"
+version = "%d.%d.%d.%s" % (MAJOR, MINOR, MICRO, PATCH)
+__version__ = "{version}"

--- a/src/pacti/__version__.py
+++ b/src/pacti/__version__.py
@@ -1,6 +1,5 @@
-MAJOR=1
-MINOR=0
-MICRO=0
-PATCH="alpha"
-version = "%d.%d.%d.%s" % (MAJOR, MINOR, MICRO, PATCH)
-__version__ = "{version}"
+"""
+Set the Pacti package version in this file
+"""
+
+__version__ = '1.0.0'


### PR DESCRIPTION
This PR adds the version query with Pacti:

```
>>> import pacti
>>> pacti.__version__
'1.0.0-alpha'
```

The version is written to the `__version__.py` file.

Merging this PR will fix #310 